### PR TITLE
Only listen for connections on localhost

### DIFF
--- a/Socket_Adapter/Socket_Adapter.cs
+++ b/Socket_Adapter/Socket_Adapter.cs
@@ -31,9 +31,9 @@ namespace BH.Adapter.Socket
         /**** Constructors                              ****/
         /***************************************************/
 
-        public SocketAdapter(string address = "127.0.0.1", int port = 8888)
+        public SocketAdapter(string address = "127.0.0.1", int port = 8888, bool localOnly = true)
         {
-            m_Link = new SocketLink_Tcp(port, address);
+            m_Link = new SocketLink_Tcp(port, address, local: localOnly);
             m_Link.DataObservers += M_Link_DataObservers;
         }
 

--- a/Socket_Adapter/Tcp/SocketLink_Tcp.cs
+++ b/Socket_Adapter/Tcp/SocketLink_Tcp.cs
@@ -42,7 +42,7 @@ namespace BH.Adapter.Socket
         /**** Constructors                              ****/
         /***************************************************/
 
-        public SocketLink_Tcp(int port = 8888, string address = "127.0.0.1", bool internalServer = true)
+        public SocketLink_Tcp(int port = 8888, string address = "127.0.0.1", bool internalServer = true, bool local = true)
         {
             // Check the port value
             if (port < 3000 || port > 65000)
@@ -52,7 +52,7 @@ namespace BH.Adapter.Socket
             if (internalServer && address == "127.0.0.1" && !Global.TcpServers.ContainsKey(port))
             {
                 SocketServer_Tcp server = new SocketServer_Tcp();
-                if (server.Start(port))
+                if (server.Start(port, local))
                     Global.TcpServers[port] = server;
             }
 

--- a/Socket_Adapter/Tcp/SocketServer_Tcp.cs
+++ b/Socket_Adapter/Tcp/SocketServer_Tcp.cs
@@ -72,7 +72,7 @@ namespace BH.Adapter.Socket
             {
                 // Start new server
                 m_Port = port;
-                m_Listener = new TcpListener(IPAddress.Any, m_Port);
+                m_Listener = new TcpListener(IPAddress.Loopback, m_Port);
                 m_Listener.Start();
 
                 // Start accepting client

--- a/Socket_Adapter/Tcp/SocketServer_Tcp.cs
+++ b/Socket_Adapter/Tcp/SocketServer_Tcp.cs
@@ -55,7 +55,7 @@ namespace BH.Adapter.Socket
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public bool Start(int port = 8888)
+        public bool Start(int port = 8888, bool local = true)
         {
             // Check the port value
             if (port < 3000 || port > 65000) 
@@ -72,7 +72,7 @@ namespace BH.Adapter.Socket
             {
                 // Start new server
                 m_Port = port;
-                m_Listener = new TcpListener(IPAddress.Loopback, m_Port);
+                m_Listener = new TcpListener(local ? IPAddress.Loopback : IPAddress.Any, m_Port);
                 m_Listener.Start();
 
                 // Start accepting client

--- a/Socket_Adapter/Udp/SocketServer_Udp.cs
+++ b/Socket_Adapter/Udp/SocketServer_Udp.cs
@@ -57,7 +57,7 @@ namespace BH.Adapter.Socket
                 m_Thread.Abort();
         }
 
-        public bool Listen(int port = 8888)
+        public bool Listen(int port = 8888, bool local = true)
         {
             /*if (m_Port == port || port == 0)
                 return true;*/
@@ -68,7 +68,7 @@ namespace BH.Adapter.Socket
             {
                 if (m_Port != port && port != 0)
                 {
-                    m_Socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+                    m_Socket.Bind(new IPEndPoint(local ? IPAddress.Loopback : IPAddress.Any, port));
                     m_Port = port;
                 }
                     

--- a/Socket_Adapter/Udp/SocketServer_Udp.cs
+++ b/Socket_Adapter/Udp/SocketServer_Udp.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.Socket
             {
                 if (m_Port != port && port != 0)
                 {
-                    m_Socket.Bind(new IPEndPoint(IPAddress.Any, port));
+                    m_Socket.Bind(new IPEndPoint(IPAddress.Loopback, port));
                     m_Port = port;
                 }
                     


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #21 

Only listens on loopback address and as such doesn't require admin rights. Currently this doesn't provide a mechanism to listen on other addresses so if that is a desired feature still then that'll need implementing. Could be a simple boolean to choose between local and "any", I don't see the need to give more granular control than that.

### Test files

Remove firewall rule for Revit, then open Revit. Or likewise for Excel/Rhino with the added step of creating a Socket_Adapter.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->