### PR TITLE
ci: point the CI workflow at BHoM/CI_Toolkit

### DIFF
--- a/.github/workflows/ci-beta.yml
+++ b/.github/workflows/ci-beta.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Run build
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-build@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-build@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
@@ -35,7 +35,7 @@ jobs:
       actions: write
     steps:
       - name: Run code compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: code
           patterns: '*.cs'
@@ -51,7 +51,7 @@ jobs:
       actions: write
     steps:
       - name: Run copyright compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: copyright
           patterns: '*.cs'
@@ -67,10 +67,10 @@ jobs:
       actions: write
     steps:
       - name: Run dataset compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: dataset
-          patterns: '**/*[Dd]atasets*/**/*.json **/*[Dd]atasets*.json'
+          patterns: ':(icase)*datasets*.json'
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
 
@@ -83,7 +83,7 @@ jobs:
       actions: write
     steps:
       - name: Run documentation compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: documentation
           patterns: '*.cs'
@@ -99,10 +99,10 @@ jobs:
       actions: write
     steps:
       - name: Run project compliance
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-compliance@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-compliance@develop
         with:
           check_type: project
-          patterns: 'AssemblyInfo.cs *.csproj'
+          patterns: '*AssemblyInfo.cs *.csproj'
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
 
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Run dataset tests
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-dataset-tests@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-dataset-tests@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
@@ -121,7 +121,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Run serialisation
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-serialisation@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-serialisation@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}
@@ -132,7 +132,7 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Run versioning
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/ci-versioning@develop
+        uses: BHoM/CI_Toolkit/.github/actions/ci-versioning@develop
         with:
           app_id: ${{ secrets.BHOM_APP_ID }}
           private_key: ${{ secrets.BHOM_APP_PRIVATE_KEY }}


### PR DESCRIPTION
CI_Toolkit moved from BuroHappoldEngineeringAdmin to BHoM. The old path redirects, so this removes a dependency on the redirect rather than fixing a break.

Also picks up two pattern corrections made since this file was copied: dataset compliance now uses a case-insensitive unanchored pathspec, and project compliance matches `AssemblyInfo.cs` at any depth instead of only at the repo root. Neither changes which files are selected in this repo today.

Still non-blocking. Tracked in CI_Toolkit_Proxy#13.